### PR TITLE
Added julia mode number highlighting

### DIFF
--- a/highlight-numbers.el
+++ b/highlight-numbers.el
@@ -150,6 +150,30 @@ It is used when no mode-specific one is available.")
                          (*? any)
                          symbol-end))
                 table)
+       (puthash 'julia-mode
+                (rx (and
+                     symbol-start
+                     (or (and (+ digit)
+                              (? (and "." (* digit)))
+                              (? (and (any "eE")
+                                      (? (any "-+"))
+                                      (+ digit))))
+                         (and "0"
+                              (any "xX")
+                              (+ hex-digit)))))
+                table)
+       (puthash 'ess-julia-mode
+                (rx (and
+                     symbol-start
+                     (or (and (+ digit)
+                              (? (and "." (* digit)))
+                              (? (and (any "eE")
+                                      (? (any "-+"))
+                                      (+ digit))))
+                         (and "0"
+                              (any "xX")
+                              (+ hex-digit)))))
+                table)
        table)))
   "Hash table storing the mode-specific number highlighting regexps.
 


### PR DESCRIPTION
This correctly highlights numbers in Julia (where numbers can prefix a variable name:`2x == 2*x`).